### PR TITLE
urllib not available

### DIFF
--- a/tools/startup.py
+++ b/tools/startup.py
@@ -30,9 +30,9 @@ print "downloading the Enron dataset (this may take a while)"
 print "to check on progress, you can cd up one level, then execute <ls -lthr>"
 print "Enron dataset should be last item on the list, along with its current size"
 print "download will complete at about 423 MB"
-import urllib
+import urllib.request
 url = "https://www.cs.cmu.edu/~./enron/enron_mail_20150507.tgz"
-urllib.urlretrieve(url, filename="../enron_mail_20150507.tgz") 
+urllib.request.urlretrieve(url, filename="../enron_mail_20150507.tgz") 
 print "download complete!"
 
 


### PR DESCRIPTION
Hi,

When i am trying to run startup.py script under tools folder, it is throwing below exception.

Exception: module 'urllib' has no attribute 'urlretrieve'

I am using Python 3.6 version with Anaconda. Also when i am trying to install urllib, it is saying no module called urllib.

The script working fine when i change like below.

import urllib.request
urllib.request.urlretrieve(url, filename="../enron_mail_20150507.tgz")

Thanks